### PR TITLE
Add block styling metadata to fragments

### DIFF
--- a/documentor/structuries/fragment/__init__.py
+++ b/documentor/structuries/fragment/__init__.py
@@ -10,6 +10,7 @@ from .code import ListingFragment
 from .formula import ImageFormulaFragment, LatexFormulaFragment
 from .hierarchy import HeaderFragment, TitleFragment, ColumnHeaderFragment
 from .table import TableFragment, ImageTableFragment
+from .style import BlockStyle, InlineStyle
 from .description import (
     IMAGE,
     TABLE,
@@ -20,3 +21,28 @@ from .description import (
     COLUMN,
     HEADER,
 )
+
+__all__ = [
+    "Fragment",
+    "TextFragment",
+    "ParagraphFragment",
+    "ImageFragment",
+    "ListingFragment",
+    "ImageFormulaFragment",
+    "LatexFormulaFragment",
+    "HeaderFragment",
+    "TitleFragment",
+    "ColumnHeaderFragment",
+    "TableFragment",
+    "ImageTableFragment",
+    "BlockStyle",
+    "InlineStyle",
+    "IMAGE",
+    "TABLE",
+    "PARAGRAPH",
+    "TITLE",
+    "LISTING",
+    "FORMULA",
+    "COLUMN",
+    "HEADER",
+]

--- a/documentor/structuries/fragment/base.py
+++ b/documentor/structuries/fragment/base.py
@@ -1,18 +1,18 @@
-"""
-Base abstractions for document fragments.
+"""Base abstractions for document fragments."""
 
-Defines the Fragment abstract base class used by all fragment types.
-"""
 import dataclasses
 from abc import ABC, abstractmethod
 from typing import Any
 
+from .style import BlockStyle
 
+
+@dataclasses.dataclass
 class Fragment(ABC):
-    """
-    Base class for fragments of any type.
+    """Base class for fragments of any type.
 
     Each fragment represents a structural unit of a document.
+
     Examples of fragments:
     - a table cell
     - a log entry
@@ -23,28 +23,27 @@ class Fragment(ABC):
         value: value of the fragment
         page: page number of the fragment
         description: description of the fragment type for LLM
+        id: optional unique identifier of the fragment
+        bbox: optional coordinates of the fragment (x1, y1, x2, y2)
+        style: block level style of the fragment
     """
+
     value: Any
     page: str | None = None
     description: str = ""
     is_processed: bool = True
+    id: str | None = None
+    bbox: tuple[int, int, int, int] | None = None
+    style: BlockStyle | None = None
 
     @abstractmethod
     def __str__(self) -> str:
-        """
-        String representation of a fragment's value.
-
-        Returns:
-            str: Value of the fragment.
-        """
+        """String representation of a fragment's value."""
         raise NotImplementedError
 
-    @abstractmethod
     def __dict__(self) -> dict[str, Any]:
-        """
-        Get parameters of the fragment.
-
-        Returns:
-            dict[str, Any]: Parameters of the fragment.
-        """
-        raise NotImplementedError
+        """Get parameters of the fragment."""
+        return {
+            field.name: getattr(self, field.name)
+            for field in dataclasses.fields(self)
+        }

--- a/documentor/structuries/fragment/image.py
+++ b/documentor/structuries/fragment/image.py
@@ -10,6 +10,7 @@ import base64
 from io import BytesIO
 
 from dataclasses import dataclass
+from typing import Any
 
 from .base import Fragment
 from .description import IMAGE
@@ -44,18 +45,15 @@ class ImageFragment(Fragment):
         self.value.save(buffered, format=self.format)
         return base64.b64encode(buffered.getvalue()).decode(self.encoding)
 
-    def __dict__(self) -> dict[str, str]:
-        """
-        Get parameters of the image fragment.
-
-        Returns:
-            dict[str, str]: Parameters of the image fragment.
-        """
-        return {
+    def __dict__(self) -> dict[str, Any]:
+        """Get parameters of the image fragment."""
+        data = super().__dict__()
+        data.update({
             "value": str(self),
             "format": self.format,
-            "encoding": self.encoding
-        }
+            "encoding": self.encoding,
+        })
+        return data
 
     @staticmethod
     def from_base64(

--- a/documentor/structuries/fragment/style.py
+++ b/documentor/structuries/fragment/style.py
@@ -1,0 +1,22 @@
+"""Style structures for fragments."""
+from dataclasses import dataclass
+
+
+@dataclass
+class BlockStyle:
+    """Block-level styling information for a fragment."""
+    font_family: str | None = None
+    font_size: float | None = None
+    font_weight: str | None = None
+    alignment: str | None = None
+    color: str | None = None
+    line_height: float | None = None
+
+
+@dataclass
+class InlineStyle:
+    """Placeholder for future inline-level styling."""
+    bold: bool | None = None
+    italic: bool | None = None
+    underline: bool | None = None
+    color: str | None = None

--- a/documentor/structuries/fragment/table.py
+++ b/documentor/structuries/fragment/table.py
@@ -64,16 +64,15 @@ class TableFragment(Fragment):
         )
 
     def __dict__(self) -> dict[str, Any]:
-        """
-        Get parameters of the table fragment.
-        """
-        return {
-            "value": self.value,
+        """Get parameters of the table fragment."""
+        data = super().__dict__()
+        data.update({
             "value_types": self.value_types,
             "cell_params": self.cell_params,
             "column_separators": self.column_separators,
-            "row_separator": self.row_separator
-        }
+            "row_separator": self.row_separator,
+        })
+        return data
 
     def get_all_params(self) -> list[dict[str, Any]]:
         """

--- a/documentor/structuries/fragment/text.py
+++ b/documentor/structuries/fragment/text.py
@@ -42,7 +42,7 @@ class TextFragment(Fragment):
 
     @overrides
     def __dict__(self) -> dict[str, Any]:
-        return {field: getattr(self, field) for field in self.__annotations__.keys()}
+        return super().__dict__()
 
 @dataclass
 class ParagraphFragment(TextFragment):

--- a/tests/structuries/fragments/test_image.py
+++ b/tests/structuries/fragments/test_image.py
@@ -31,6 +31,19 @@ def test_image_fragment_roundtrip_base64(fname, data_dir):
     assert frag.description == IMAGE
 
     d = frag.__dict__()
-    assert set(d.keys()) == {"value", "format", "encoding"}
+    assert set(d.keys()) == {
+        "value",
+        "format",
+        "encoding",
+        "page",
+        "description",
+        "is_processed",
+        "id",
+        "bbox",
+        "style",
+    }
+    assert d["id"] is None
+    assert d["bbox"] is None
+    assert d["style"] is None
     # Ensure value is valid base64
     base64.b64decode(d["value"].encode("utf-8"))


### PR DESCRIPTION
## Summary
- introduce `BlockStyle` and placeholder `InlineStyle`
- extend `Fragment` with id, bbox and block-level style
- update text, image and table fragments to serialize new metadata
- export styling structures and adjust image fragment tests
- make fragment id and bounding box optional

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b95c4fecf48332bb3847d07e7790df