### PR TITLE
Add pluggable OCR scan pipeline and parsers integration

### DIFF
--- a/documentor/parsers/__init__.py
+++ b/documentor/parsers/__init__.py
@@ -1,0 +1,6 @@
+"""Collection of built-in document parsers."""
+
+from .image import ImageParser
+from .pdf import PdfParser
+
+__all__ = ["ImageParser", "PdfParser"]

--- a/documentor/parsers/image/__init__.py
+++ b/documentor/parsers/image/__init__.py
@@ -1,0 +1,53 @@
+"""Image parser powered by the OCR scan pipeline."""
+
+from __future__ import annotations
+
+from typing import Iterator
+from io import BytesIO
+
+try:  # pragma: no cover - optional dependency
+    from PIL import Image
+except Exception:  # pragma: no cover
+    Image = None
+
+from documentor.parsers.base import BaseBlobParser
+from documentor.parsers.extensions import DocExtension
+from documentor.parsers.config import ParsingSchema
+from documentor.structuries.document import Document, Metadata
+from documentor.structuries.fragment.base import Fragment
+from documentor.pipelines.ocr import ScanPipeline
+from langchain_core.documents.base import Blob
+
+
+class ImageParser(BaseBlobParser):
+    """Parse images using a :class:`~documentor.pipelines.ocr.ScanPipeline`."""
+
+    _extensions = {DocExtension.jpg, DocExtension.jpeg, DocExtension.png}
+    _available_parsing_schemas = {ParsingSchema.full}
+
+    def __init__(self, pipeline: ScanPipeline, **kwargs) -> None:
+        self.pipeline = pipeline
+        super().__init__(**kwargs)
+
+    def _create_document(
+        self,
+        fragments: list[Fragment],
+        line_number: int,
+        file_name: str | None,
+        source: Blob | None,
+        file_type: str | None,
+    ) -> Document:
+        metadata = Metadata(name=file_name, extension=file_type, source=source)
+        return Document(fragments=fragments, metadata=metadata)
+
+    def _build_document(self, fragments: list[Fragment], line_number: int, blob: Blob) -> Document:
+        file_name = blob.path.name if blob.path else None
+        file_type = blob.path.suffix if blob.path else None
+        return self._create_document(fragments, line_number, file_name, blob, file_type)
+
+    def lazy_parse(self, blob: Blob) -> Iterator[Document]:
+        if Image is None:
+            raise ImportError("Pillow is required to parse image files")
+        image = Image.open(BytesIO(blob.as_bytes()))
+        fragments = list(self.pipeline(image))
+        yield self._build_document(fragments, 0, blob)

--- a/documentor/parsers/pdf/__init__.py
+++ b/documentor/parsers/pdf/__init__.py
@@ -1,0 +1,59 @@
+"""PDF parser that relies on the OCR scan pipeline."""
+
+from __future__ import annotations
+
+from typing import Iterable, Any, Callable, Iterator
+
+from documentor.parsers.base import BaseBlobParser
+from documentor.parsers.extensions import DocExtension
+from documentor.parsers.config import ParsingSchema
+from documentor.structuries.document import Document, Metadata
+from documentor.structuries.fragment.base import Fragment
+from documentor.pipelines.ocr import ScanPipeline
+from langchain_core.documents.base import Blob
+
+try:  # pragma: no cover - optional dependency
+    from pdf2image import convert_from_bytes  # type: ignore
+except Exception:  # pragma: no cover
+    convert_from_bytes = None
+
+
+class PdfParser(BaseBlobParser):
+    """Parse PDF bytes using a :class:`~documentor.pipelines.ocr.ScanPipeline`."""
+
+    _extensions = {DocExtension.pdf}
+    _available_parsing_schemas = {ParsingSchema.full}
+
+    def __init__(
+        self,
+        pipeline: ScanPipeline,
+        pdf_to_images: Callable[[bytes], Iterable[Any]] | None = None,
+        **kwargs,
+    ) -> None:
+        self.pipeline = pipeline
+        self._pdf_to_images = pdf_to_images or convert_from_bytes
+        super().__init__(**kwargs)
+
+    def _create_document(
+        self,
+        fragments: list[Fragment],
+        page_number: int,
+        file_name: str | None,
+        source: Blob | None,
+        file_type: str | None,
+    ) -> Document:
+        metadata = Metadata(name=file_name, extension=file_type, source=source, page=page_number)
+        return Document(fragments=fragments, metadata=metadata)
+
+    def _build_document(self, fragments: list[Fragment], page_number: int, blob: Blob) -> Document:
+        file_name = blob.path.name if blob.path else None
+        file_type = blob.path.suffix if blob.path else None
+        return self._create_document(fragments, page_number, file_name, blob, file_type)
+
+    def lazy_parse(self, blob: Blob) -> Iterator[Document]:
+        if self._pdf_to_images is None:
+            raise ImportError("pdf2image is required to parse PDF files")
+        pdf_bytes = blob.as_bytes()
+        for page_number, page_image in enumerate(self._pdf_to_images(pdf_bytes)):
+            fragments = list(self.pipeline(page_image))
+            yield self._build_document(fragments, page_number, blob)

--- a/documentor/pipelines/__init__.py
+++ b/documentor/pipelines/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline abstractions for document processing."""

--- a/documentor/pipelines/ocr/__init__.py
+++ b/documentor/pipelines/ocr/__init__.py
@@ -1,0 +1,19 @@
+"""OCR pipeline utilities."""
+
+from .interfaces import (
+    Block,
+    BlockDetector,
+    BlockClassifier,
+    OrderRestorer,
+    BlockRecognizer,
+)
+from .pipeline import ScanPipeline
+
+__all__ = [
+    "Block",
+    "BlockDetector",
+    "BlockClassifier",
+    "OrderRestorer",
+    "BlockRecognizer",
+    "ScanPipeline",
+]

--- a/documentor/pipelines/ocr/interfaces.py
+++ b/documentor/pipelines/ocr/interfaces.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Interfaces for OCR pipeline stages.
+
+These minimal ABCs define the contract for each stage of an OCR pipeline.
+Custom implementations can be provided to plug into the :class:`ScanPipeline`.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Iterable, Any
+
+from documentor.structuries.fragment.base import Fragment
+
+
+@dataclass
+class Block:
+    """Container representing a detected block in an image.
+
+    The block may represent a line of text, table, image or any other
+    structural element detected on a page.  The container keeps only the
+    minimum information required for the subsequent stages of the pipeline
+    and deliberately avoids tying to any specific OCR library.
+
+    Attributes:
+        image:    Cropped image data for the block.  Type is intentionally
+                   loose to allow use of any imaging library (e.g. PIL, numpy).
+        bbox:     Optional bounding box in (x1, y1, x2, y2) coordinates.
+        category: Optional classification label supplied by
+                  :class:`BlockClassifier`.
+        order:    Optional index representing the reading order.
+    """
+
+    image: Any
+    bbox: tuple[int, int, int, int] | None = None
+    category: str | None = None
+    order: int | None = None
+
+
+class BlockDetector(ABC):
+    """Stage responsible for locating blocks on a page image."""
+
+    @abstractmethod
+    def detect(self, image: Any) -> Iterable[Block]:
+        """Detect blocks on a raw page image."""
+        raise NotImplementedError
+
+
+class BlockClassifier(ABC):
+    """Stage responsible for assigning semantic labels to blocks."""
+
+    @abstractmethod
+    def classify(self, blocks: Iterable[Block]) -> Iterable[Block]:
+        """Annotate blocks with semantic categories."""
+        raise NotImplementedError
+
+
+class OrderRestorer(ABC):
+    """Stage that establishes reading order for blocks."""
+
+    @abstractmethod
+    def restore(self, blocks: Iterable[Block]) -> Iterable[Block]:
+        """Return blocks in the desired reading order."""
+        raise NotImplementedError
+
+
+class BlockRecognizer(ABC):
+    """Stage that converts blocks into :class:`Fragment` objects."""
+
+    @abstractmethod
+    def recognize(self, blocks: Iterable[Block]) -> Iterable[Fragment]:
+        """Yield :class:`Fragment` objects with recognized content."""
+        raise NotImplementedError

--- a/documentor/pipelines/ocr/pipeline.py
+++ b/documentor/pipelines/ocr/pipeline.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Orchestration of OCR pipeline stages."""
+
+from typing import Iterable, Iterator, Any
+
+from documentor.structuries.fragment.base import Fragment
+
+from .interfaces import (
+    BlockDetector,
+    BlockClassifier,
+    OrderRestorer,
+    BlockRecognizer,
+)
+
+
+class ScanPipeline:
+    """Run a sequence of OCR stages to produce :class:`Fragment` objects.
+
+    The pipeline is deliberately lightweight.  Every stage is pluggable and
+    may be swapped for custom implementations, e.g. a different detector or a
+    recognizer using another LLM prompt.
+    """
+
+    def __init__(
+        self,
+        detector: BlockDetector,
+        classifier: BlockClassifier | None = None,
+        order_restorer: OrderRestorer | None = None,
+        recognizer: BlockRecognizer | None = None,
+    ) -> None:
+        self.detector = detector
+        self.classifier = classifier
+        self.order_restorer = order_restorer
+        self.recognizer = recognizer
+
+    def process(self, image: Any) -> Iterator[Fragment]:
+        """Process a page image through all configured stages."""
+
+        blocks: Iterable = self.detector.detect(image)
+
+        if self.classifier is not None:
+            blocks = self.classifier.classify(blocks)
+
+        if self.order_restorer is not None:
+            blocks = self.order_restorer.restore(blocks)
+
+        if self.recognizer is None:
+            return iter(())
+
+        yield from self.recognizer.recognize(blocks)
+
+    # Allow the pipeline instance to be called directly
+    __call__ = process

--- a/documentor/structuries/document/base.py
+++ b/documentor/structuries/document/base.py
@@ -1,5 +1,13 @@
 from typing import Iterator
 
+try:  # pragma: no cover - optional langchain dependency
+    from langchain_core.documents import Document as LCDocument
+except Exception:  # pragma: no cover
+    class LCDocument:  # type: ignore[override]
+        def __init__(self, page_content: str = "", metadata: dict | None = None) -> None:
+            self.page_content = page_content
+            self.metadata = metadata or {}
+
 import pandas as pd
 
 from structuries.fragment import Fragment
@@ -7,7 +15,7 @@ from structuries.metadata import Metadata
 from structuries.structure import DocumentStructure
 
 
-class Document:
+class Document(LCDocument):
     """
     Base interface for documents that contain a sequence of fragments.
 
@@ -23,22 +31,18 @@ class Document:
     metadata: Metadata
 
     def __init__(
-            self,
-            fragments: list[Fragment],
-            structure: DocumentStructure | None = None,
-            metadata: Metadata | None = None,
-    ):
-        """
-        Initialize a Document.
-
-        Args:
-            fragments: The list of fragments contained in the document.
-            structure: Optional structural representation of the document.
-        """
-        self._fragments = fragments
-        self.structure = structure
+        self,
+        fragments: list[Fragment],
+        structure: DocumentStructure | None = None,
+        metadata: Metadata | None = None,
+    ) -> None:
+        """Initialize a Document."""
         if metadata is None:
             metadata = Metadata()
+        text = "\n".join(str(fragment) for fragment in fragments)
+        super().__init__(page_content=text, metadata=dict(metadata.__dict__))
+        self._fragments = fragments
+        self.structure = structure
         self.metadata = metadata
 
     def fragments(self) -> list[Fragment]:


### PR DESCRIPTION
## Summary
- introduce `documentor.pipelines.ocr` with interfaces for OCR stages and a `ScanPipeline` orchestrator
- add lightweight image and PDF parsers that run the OCR pipeline and export them in the parsers package
- hook image/PDF parsers into `BaseBlobParser` and make `Document` inherit from LangChain's `Document`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b96f54c7b88332a44161f95e69915b