### PR TITLE
Implement efficient fragment lookup in DocumentStructure

### DIFF
--- a/documentor/structuries/structure.py
+++ b/documentor/structuries/structure.py
@@ -1,104 +1,395 @@
-from abc import ABC, abstractmethod
 from collections.abc import Hashable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import chain
 from typing import Optional
 
 import pandas as pd
 
-from documentor.structuries.fragment import Fragment
-from structuries.fragment import HeaderFragment
+from structuries.fragment import Fragment, HeaderFragment
 
 
 @dataclass(frozen=True)
 class StructureNode:
+    """Node of a document hierarchy.
+
+    Attributes:
+        children: Child nodes. An empty list marks a leaf.
+        value: Associated fragment or ``None`` for synthetic roots.
     """
-    Class for nodes with elements of the hierarchical structure of a document.
-    """
-    children: list['StructureNode'] | None = None
+
+    children: list["StructureNode"] = field(default_factory=list)
     value: Fragment | None = None
 
     @property
     def fragments(self) -> list[Fragment]:
-        """
-        Get all leaf fragments of the node and its children.
+        """Return all leaf fragments within this subtree.
 
         Returns:
-            list[Fragment]: List of fragments.
+            list[Fragment]: Collected leaf fragments.
         """
-        ans = []
-        if self.children is None:
-            ans = [self.value] if self.value is not None else []
-        else:
-            ans = list(chain(c.fragments for c in self.children))
-        return ans
+
+        if not self.children:
+            return [self.value] if self.value is not None else []
+        return list(chain.from_iterable(c.fragments for c in self.children))
 
     def structure(self, level: int = 0) -> list[tuple[Fragment, int]]:
-        """
-        Get all fragments and their levels in the document structure.
+        """Return ``(fragment, level)`` pairs for the subtree.
+
         Args:
-            level: int = 0 - current level
+            level (int, optional): Starting level for this node. Defaults to ``0``.
 
         Returns:
-            structure: list[tuple[Fragment, int]] - list of tuples with fragment and level
-
+            list[tuple[Fragment, int]]: Fragment and its hierarchy level.
         """
+
         ans = [(self.value, level)] if self.value is not None else []
         if self.children:
-            ans += list(chain(c.structure(level + 1) for c in self.children))
+            ans += list(chain.from_iterable(c.structure(level + 1) for c in self.children))
         return ans
 
 
 @dataclass(frozen=True)
 class DocumentStructure:
+    """Hierarchical structure of document fragments.
+
+    The class precomputes various relations between fragments to provide
+    ``O(1)`` access to neighbours, parents, children and other metadata.
+
+    Attributes:
+        root: Root node of the hierarchy.
+    """
+
     root: StructureNode
+    _id_to_node: dict[str, StructureNode] = field(init=False, repr=False)
+    _id_to_parent: dict[str, Optional[str]] = field(init=False, repr=False)
+    _id_to_children: dict[str, list[str]] = field(init=False, repr=False)
+    _content_to_id: dict[Hashable, str] = field(init=False, repr=False)
+    _id_to_prev: dict[str, Optional[str]] = field(init=False, repr=False)
+    _id_to_next: dict[str, Optional[str]] = field(init=False, repr=False)
+    _id_to_level: dict[str, int] = field(init=False, repr=False)
+    _obj_to_id: dict[int, str] = field(init=False, repr=False)
+
+    @classmethod
+    def from_level_pairs(
+        cls, pairs: list[tuple[int, Fragment]]
+    ) -> "DocumentStructure":
+        """Create a ``DocumentStructure`` from ``(level, fragment)`` pairs.
+
+        The input must list fragments in reading order with their hierarchy
+        levels starting from ``0``. If multiple fragments are provided at level
+        ``0``, they will be attached to an empty top-level node.
+
+        Args:
+            pairs: Sequence of ``(level, fragment)`` tuples describing the
+                hierarchy.
+
+        Returns:
+            DocumentStructure: Constructed hierarchy.
+
+        Raises:
+            ValueError: If ``pairs`` is empty or levels are inconsistent.
+        """
+
+        if not pairs:
+            raise ValueError("pairs cannot be empty")
+
+        idx = 0
+        roots: list[StructureNode] = []
+        while idx < len(pairs):
+            node, idx = cls._parse_pairs(pairs, idx, 0)
+            roots.append(node)
+
+        root = roots[0] if len(roots) == 1 else StructureNode(children=roots)
+        return cls(root)
+
+    @staticmethod
+    def _parse_pairs(
+        pairs: list[tuple[int, Fragment]], idx: int, expected_level: int
+    ) -> tuple[StructureNode, int]:
+        """Recursive helper for :meth:`from_level_pairs`.
+
+        Args:
+            pairs: Sequence being parsed.
+            idx: Current index in ``pairs``.
+            expected_level: Level expected for the current fragment.
+
+        Returns:
+            tuple[StructureNode, int]: Constructed node and next index.
+
+        Raises:
+            ValueError: If hierarchy levels are inconsistent.
+        """
+
+        if idx >= len(pairs):
+            raise ValueError("unexpected end of pairs")
+        level, fragment = pairs[idx]
+        if level != expected_level:
+            raise ValueError("invalid level sequence")
+        idx += 1
+        children: list[StructureNode] = []
+        while idx < len(pairs) and pairs[idx][0] > expected_level:
+            next_level = pairs[idx][0]
+            if next_level != expected_level + 1:
+                raise ValueError("invalid level jump")
+            child, idx = DocumentStructure._parse_pairs(pairs, idx, expected_level + 1)
+            children.append(child)
+        return StructureNode(value=fragment, children=children), idx
+
+    def __post_init__(self) -> None:
+        """Build helper mappings for constant-time lookups."""
+
+        id_to_node: dict[str, StructureNode] = {}  # fragment id -> node
+        id_to_parent: dict[str, Optional[str]] = {}  # fragment id -> parent id
+        id_to_children: dict[str, list[str]] = {}  # fragment id -> child ids
+        content_to_id: dict[Hashable, str] = {}  # fragment value -> id
+        id_to_prev: dict[str, Optional[str]] = {}  # fragment id -> previous id
+        id_to_next: dict[str, Optional[str]] = {}  # fragment id -> next id
+        id_to_level: dict[str, int] = {}  # fragment id -> level
+        obj_to_id: dict[int, str] = {}  # object identity -> fragment id
+
+        def traverse(
+            node: StructureNode, parent_id: Optional[str], level: int
+        ) -> Optional[str]:
+            """Populate lookup tables by walking the tree."""
+
+            node_id: Optional[str] = None
+            if node.value is not None:
+                node_id = node.value.id or str(id(node.value))
+                id_to_node[node_id] = node
+                id_to_parent[node_id] = parent_id
+                id_to_children[node_id] = []
+                id_to_level[node_id] = level
+                obj_to_id[id(node.value)] = node_id
+                try:
+                    content_to_id.setdefault(node.value.value, node_id)
+                except TypeError:
+                    pass
+                id_to_prev[node_id] = None
+                id_to_next[node_id] = None
+
+            if node.children:
+                prev_child_id: Optional[str] = None
+                for child in node.children:
+                    child_id = traverse(child, node_id, level + 1)
+                    if child_id is None:
+                        continue
+                    if node_id is not None:
+                        id_to_children[node_id].append(child_id)
+                    if prev_child_id is not None:
+                        id_to_next[prev_child_id] = child_id
+                        id_to_prev[child_id] = prev_child_id
+                    prev_child_id = child_id
+                if prev_child_id is not None:
+                    id_to_next[prev_child_id] = None
+
+            return node_id
+
+        traverse(self.root, None, 0)
+
+        object.__setattr__(self, "_id_to_node", id_to_node)
+        object.__setattr__(self, "_id_to_parent", id_to_parent)
+        object.__setattr__(self, "_id_to_children", id_to_children)
+        object.__setattr__(self, "_content_to_id", content_to_id)
+        object.__setattr__(self, "_id_to_prev", id_to_prev)
+        object.__setattr__(self, "_id_to_next", id_to_next)
+        object.__setattr__(self, "_id_to_level", id_to_level)
+        object.__setattr__(self, "_obj_to_id", obj_to_id)
 
     @property
     def structure(self) -> list[tuple[Fragment, int]]:
-        return self.root.structure()
-
-    def fragments(self) -> list[Fragment]:
-        return self.root.fragments
-
-    def previous(self, fragment: Fragment | str) -> Optional[Fragment]:
-        """
-        Find the previous fragment (or fragment id) in the document in the current hierarchy level.
-        Returns None if the fragment is the first one in the hierarchy.
-        """
-        pass
-
-    def next(self, fragment: Fragment | str) -> Optional[Fragment]:
-        """
-        Find the next fragment (or fragment id) in the document in the current hierarchy level.
-        Returns None if the fragment is the last one in the hierarchy.
-        Args:
-            fragment:
+        """Return a linear representation of the hierarchy.
 
         Returns:
-
+            list[tuple[Fragment, int]]: Fragment and level pairs.
         """
-        pass
+
+        return self.root.structure()
+
+    @property
+    def fragments(self) -> list[Fragment]:
+        """Return all leaf fragments in the structure.
+
+        Returns:
+            list[Fragment]: Leaf fragments of the document.
+        """
+
+        return self.root.fragments
+
+    def _resolve_id(self, fragment: Fragment | str) -> Optional[str]:
+        """Get internal fragment identifier.
+
+        Args:
+            fragment: Fragment instance or its string identifier.
+
+        Returns:
+            Optional[str]: Fragment identifier if the fragment is known,
+            otherwise ``None``.
+        """
+
+        if isinstance(fragment, str):
+            return fragment if fragment in self._id_to_node else None
+        if fragment.id and fragment.id in self._id_to_node:
+            return fragment.id
+        return self._obj_to_id.get(id(fragment))
 
     def get_fragment_by_id(self, fragment_id: str) -> Optional[Fragment]:
-        pass
+        """Retrieve a fragment by its identifier.
+
+        Args:
+            fragment_id: Identifier of the fragment.
+
+        Returns:
+            Optional[Fragment]: Fragment with the given identifier or ``None``.
+        """
+
+        node = self._id_to_node.get(fragment_id)
+        return node.value if node else None
 
     def get_fragment_by_content(self, content: Hashable) -> Optional[Fragment]:
-        pass
+        """Find a fragment by its ``value`` field.
+
+        Args:
+            content: Fragment value to search for.
+
+        Returns:
+            Optional[Fragment]: Found fragment or ``None`` if absent.
+        """
+
+        fragment_id = self._content_to_id.get(content)
+        return self.get_fragment_by_id(fragment_id) if fragment_id else None
+
+    def previous(self, fragment: Fragment | str) -> Optional[Fragment]:
+        """Return the previous fragment on the same hierarchy level.
+
+        Args:
+            fragment: Fragment instance or its identifier.
+
+        Returns:
+            Optional[Fragment]: Previous fragment or ``None`` if there is no one.
+        """
+
+        fragment_id = self._resolve_id(fragment)
+        if fragment_id is None:
+            return None
+        prev_id = self._id_to_prev.get(fragment_id)
+        return self.get_fragment_by_id(prev_id) if prev_id else None
+
+    def next(self, fragment: Fragment | str) -> Optional[Fragment]:
+        """Return the next fragment on the same hierarchy level.
+
+        Args:
+            fragment: Fragment instance or its identifier.
+
+        Returns:
+            Optional[Fragment]: Next fragment or ``None`` if it is the last one.
+        """
+
+        fragment_id = self._resolve_id(fragment)
+        if fragment_id is None:
+            return None
+        next_id = self._id_to_next.get(fragment_id)
+        return self.get_fragment_by_id(next_id) if next_id else None
 
     def parent(self, fragment: Fragment | str) -> Optional[Fragment]:
-        pass
+        """Return the parent fragment of ``fragment``.
+
+        Args:
+            fragment: Fragment instance or its identifier.
+
+        Returns:
+            Optional[Fragment]: Parent fragment or ``None`` if at root level.
+        """
+
+        fragment_id = self._resolve_id(fragment)
+        if fragment_id is None:
+            return None
+        parent_id = self._id_to_parent.get(fragment_id)
+        return self.get_fragment_by_id(parent_id) if parent_id else None
 
     def children(self, fragment: Fragment | str) -> list[Fragment]:
-        pass
+        """Return child fragments of ``fragment``.
 
-    def hierarchy(self):
-        pass
+        Args:
+            fragment: Fragment instance or its identifier.
+
+        Returns:
+            list[Fragment]: Direct child fragments.
+
+        Raises:
+            ValueError: If ``fragment`` is not part of the structure.
+        """
+
+        fragment_id = self._resolve_id(fragment)
+        if fragment_id is None:
+            raise ValueError("Fragment not found in structure")
+        children_ids = self._id_to_children.get(fragment_id, [])
+        return [self._id_to_node[cid].value for cid in children_ids]
+
+    def hierarchy(self) -> pd.DataFrame:
+        """Return a ``pandas.DataFrame`` describing the hierarchy.
+
+        The dataframe contains columns: ``id``, ``parent_id`` and ``level``.
+
+        Returns:
+            pandas.DataFrame: Hierarchy representation.
+        """
+
+        rows = [
+            {
+                "id": fid,
+                "parent_id": self._id_to_parent[fid],
+                "level": self._id_to_level[fid],
+                "fragment": self._id_to_node[fid].value,
+            }
+            for fid in self._id_to_node
+        ]
+        return pd.DataFrame(rows)
 
     def is_leaf(self, fragment: Fragment | str) -> bool:
-        pass
+        """Check whether ``fragment`` has no children.
+
+        Args:
+            fragment: Fragment instance or its identifier.
+
+        Returns:
+            bool: ``True`` if ``fragment`` is a leaf.
+
+        Raises:
+            ValueError: If ``fragment`` is not part of the structure.
+        """
+
+        fragment_id = self._resolve_id(fragment)
+        if fragment_id is None:
+            raise ValueError("Fragment not found in structure")
+        return len(self._id_to_children.get(fragment_id, [])) == 0
 
     def is_header(self, fragment: Fragment | str) -> bool:
-        pass
+        """Check whether ``fragment`` is a ``HeaderFragment``.
+
+        Args:
+            fragment: Fragment instance or its identifier.
+
+        Returns:
+            bool: ``True`` if ``fragment`` is a header fragment.
+        """
+
+        frag = fragment if isinstance(fragment, Fragment) else self.get_fragment_by_id(fragment)
+        return isinstance(frag, HeaderFragment)
 
     def get_level(self, fragment: Fragment | str) -> int:
-        pass
+        """Return hierarchy level of ``fragment``.
+
+        Args:
+            fragment: Fragment instance or its identifier.
+
+        Returns:
+            int: Zero-based level within the hierarchy.
+
+        Raises:
+            ValueError: If ``fragment`` is not part of the structure.
+        """
+
+        fragment_id = self._resolve_id(fragment)
+        if fragment_id is None:
+            raise ValueError("Fragment not found in structure")
+        return self._id_to_level[fragment_id]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
-testpaths = tests/structuries/fragments
+testpaths =
+    tests/structuries/fragments
+    tests/structuries/structure
+pythonpath =
+    documentor

--- a/tests/structuries/structure/test_document_structure.py
+++ b/tests/structuries/structure/test_document_structure.py
@@ -1,0 +1,142 @@
+import pytest
+
+from structuries.structure import DocumentStructure, StructureNode
+from structuries.fragment.hierarchy import HeaderFragment
+from structuries.fragment.text import TextFragment
+
+
+@pytest.fixture
+def sample_structure():
+    """Create a small hierarchy for testing."""
+    a1 = TextFragment("A1", id="a1")
+    a2 = TextFragment("A2", id="a2")
+    b1 = TextFragment("B1", id="b1")
+    b2 = TextFragment("B2", id="b2")
+    ha = HeaderFragment("A", id="ha")
+    hb = HeaderFragment("B", id="hb")
+    root = StructureNode(
+        children=[
+            StructureNode(value=ha, children=[StructureNode(value=a1), StructureNode(value=a2)]),
+            StructureNode(value=hb, children=[StructureNode(value=b1), StructureNode(value=b2)]),
+        ]
+    )
+    structure = DocumentStructure(root)
+    return structure, {"ha": ha, "hb": hb, "a1": a1, "a2": a2, "b1": b1, "b2": b2}
+
+
+def test_neighbors(sample_structure):
+    """Fragments should navigate to their siblings correctly."""
+    ds, fr = sample_structure
+    assert ds.next(fr["ha"]) is fr["hb"]
+    assert ds.previous(fr["hb"]) is fr["ha"]
+    assert ds.next(fr["a1"]) is fr["a2"]
+    assert ds.previous(fr["a2"]) is fr["a1"]
+    assert ds.previous(fr["a1"]) is None
+    assert ds.next(fr["a2"]) is None
+
+
+def test_parent_children_and_leaf(sample_structure):
+    """Validate parent/child relations and leaf detection."""
+    ds, fr = sample_structure
+    assert ds.parent(fr["a1"]) is fr["ha"]
+    assert ds.parent(fr["ha"]) is None
+    assert ds.children(fr["ha"]) == [fr["a1"], fr["a2"]]
+    assert ds.children(fr["a1"]) == []
+    assert ds.is_leaf(fr["a1"]) is True
+    assert ds.is_leaf(fr["ha"]) is False
+
+
+def test_invalid_fragment_errors(sample_structure):
+    """Unknown fragments should raise ``ValueError`` for certain operations."""
+    ds, _ = sample_structure
+    with pytest.raises(ValueError):
+        ds.children("missing")
+    with pytest.raises(ValueError):
+        ds.is_leaf("missing")
+
+
+def test_levels(sample_structure):
+    """Hierarchy level lookup works for fragments."""
+    ds, fr = sample_structure
+    assert ds.get_level(fr["ha"]) == 1
+    assert ds.get_level(fr["a1"]) == 2
+
+
+def test_lookup(sample_structure):
+    """Lookup by id and content returns correct fragments."""
+    ds, fr = sample_structure
+    assert ds.get_fragment_by_id("b1") is fr["b1"]
+    assert ds.get_fragment_by_content("B2") is fr["b2"]
+    assert ds.get_fragment_by_id("missing") is None
+    assert ds.get_fragment_by_content("zzz") is None
+
+
+def test_structure_hierarchy_and_header(sample_structure):
+    """Validate hierarchy flattening and header detection."""
+    ds, fr = sample_structure
+    assert ds.is_header(fr["ha"]) is True
+    assert ds.is_header(fr["a1"]) is False
+
+    assert ds.fragments == [fr["a1"], fr["a2"], fr["b1"], fr["b2"]]
+    assert ds.structure == [
+        (fr["ha"], 1),
+        (fr["a1"], 2),
+        (fr["a2"], 2),
+        (fr["hb"], 1),
+        (fr["b1"], 2),
+        (fr["b2"], 2),
+    ]
+
+    df = ds.hierarchy()
+    assert set(df.columns) == {"id", "parent_id", "level", "fragment"}
+    assert len(df) == 6
+    row = df[df["id"] == "a1"].iloc[0]
+    assert row["parent_id"] == "ha"
+    assert row["level"] == 2
+    assert row["fragment"] is fr["a1"]
+
+
+def test_from_level_pairs():
+    """Construct structure from ``(level, fragment)`` pairs."""
+    f1 = TextFragment("F1", id="f1")
+    f2 = TextFragment("F2", id="f2")
+    f3 = TextFragment("F3", id="f3")
+    f4 = TextFragment("F4", id="f4")
+    f5 = TextFragment("F5", id="f5")
+    f6 = TextFragment("F6", id="f6")
+
+    pairs = [
+        (0, f1),
+        (1, f2),
+        (2, f3),
+        (2, f4),
+        (1, f5),
+        (2, f6),
+    ]
+
+    ds = DocumentStructure.from_level_pairs(pairs)
+
+    assert ds.structure == [
+        (f1, 0),
+        (f2, 1),
+        (f3, 2),
+        (f4, 2),
+        (f5, 1),
+        (f6, 2),
+    ]
+    assert ds.children(f1) == [f2, f5]
+    assert ds.parent(f5) is f1
+    assert ds.parent(f3) is f2
+    assert ds.next(f3) is f4
+    assert ds.previous(f5) is f2
+
+
+def test_from_level_pairs_multiple_roots():
+    """Multiple top-level nodes require a synthetic root."""
+    a = TextFragment("A", id="a")
+    b = TextFragment("B", id="b")
+    ds = DocumentStructure.from_level_pairs([(0, a), (0, b)])
+
+    assert ds.structure == [(a, 1), (b, 1)]
+    assert ds.parent(a) is None
+    assert ds.parent(b) is None


### PR DESCRIPTION
## Summary
- refine document hierarchy model with explicit child lists and property accessors
- extract reusable pair-parsing helper and document lookup table construction
- validate fragment references and streamline tests via pytest `pythonpath`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bef97827f48332bfbbc866b37fdaea